### PR TITLE
remove soundcloud refs from types, no longer used

### DIFF
--- a/lib/data.ts
+++ b/lib/data.ts
@@ -2,7 +2,7 @@ import type { DualPost, ApiPost } from './types';
 
 export function toDual(api: ApiPost): DualPost {
   const category =
-    !api.metadata.category || api.metadata.category.key === 'post' ? 'post' : 'teaching';
+    !api.metadata.category || api.metadata.category.key === `post` ? `post` : `teaching`;
   return {
     en: {
       lang: `en`,
@@ -10,7 +10,6 @@ export function toDual(api: ApiPost): DualPost {
       slug: api.slug,
       title: api.title,
       content: api.content,
-      soundcloudId: api.metadata.soundcloud_id,
       mp3Url: api.metadata.mp3_url,
       audioSize: api.metadata.audio_size,
       audioDuration: api.metadata.audio_duration,
@@ -26,7 +25,6 @@ export function toDual(api: ApiPost): DualPost {
       slug: api.metadata.spanish_slug,
       title: api.metadata.spanish_title,
       content: api.metadata.spanish_content,
-      soundcloudId: api.metadata.spanish_soundcloud_id,
       mp3Url: api.metadata.spanish_mp3_url,
       audioSize: api.metadata.spanish_audio_size,
       audioDuration: api.metadata.spanish_audio_duration,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,14 +9,12 @@ export type ApiPost = {
   metadata: {
     description?: string;
     spanish_description?: string;
-    soundcloud_id: number;
     mp3_url: string;
     audio_size: number;
     audio_duration: number;
     spanish_title: string;
     spanish_slug: string;
     spanish_content: string;
-    spanish_soundcloud_id: number;
     spanish_mp3_url: string;
     spanish_audio_size: number;
     spanish_audio_duration: number;
@@ -35,7 +33,6 @@ export type Post<L extends Lang> = {
   slug: string;
   title: string;
   content: string;
-  soundcloudId: number;
   mp3Url: string;
   audioSize: number;
   audioDuration: number;


### PR DESCRIPTION
i removed these fields from Cosmic, they were required, and there's no point for jason to enter them any more, so pulled them out of the codebase here as well, they weren't being used anywhere.