### PR TITLE
Prevent Jason Henderson from wrapping across lines

### DIFF
--- a/app/(ui)/page.tsx
+++ b/app/(ui)/page.tsx
@@ -153,7 +153,7 @@ const content = {
     title: `La Senda Antigua`,
     subtitlePrefix: `Escritos, enseñanzas y recursos recomendados de `,
     name: `Jason Henderson`,
-    subtitleSuffix: `.`,
+    subtitleSuffix: ``,
     metaDescription: `Un blog y podcast que contiene los escritos y enseñanzas de Jason R. Henderson.`,
     recentPostsLabel: `Próximamente: publicaciones recientes`,
     buttons: {

--- a/app/(ui)/page.tsx
+++ b/app/(ui)/page.tsx
@@ -27,7 +27,9 @@ const Home: NextPage = async () => {
           {c.title}
         </h1>
         <h2 className="mt-4 md:mt-6 text-xl md:text-2xl max-w-2xl text-center text-slate-800/70">
-          {c.subtitle}
+          {c.subtitlePrefix}
+          <span className="whitespace-nowrap">{c.name}</span>
+          {c.subtitleSuffix}
         </h2>
         <div className="mt-12 w-full xs:w-96 md:w-auto flex flex-col md:flex-row gap-4">
           <div className="flex flex-col xs:flex-row flex-wrap justify-center gap-4 max-w-2xl">
@@ -107,7 +109,9 @@ export default Home;
 const content = {
   en: {
     title: `The Ancient Path`,
-    subtitle: `Writings, teachings, and recommended resources from Jason Henderson`,
+    subtitlePrefix: `Writings, teachings, and recommended resources from `,
+    name: `Jason Henderson`,
+    subtitleSuffix: ``,
     metaDescription: `A blog and podcast containing the writings and teachings of Jason R. Henderson.`,
     recentPostsLabel: `Coming soon: recent posts`,
     buttons: {
@@ -147,7 +151,9 @@ const content = {
   },
   es: {
     title: `La Senda Antigua`,
-    subtitle: `Escritos, enseñanzas y recursos recomendados de Jason Henderson.`,
+    subtitlePrefix: `Escritos, enseñanzas y recursos recomendados de `,
+    name: `Jason Henderson`,
+    subtitleSuffix: `.`,
     metaDescription: `Un blog y podcast que contiene los escritos y enseñanzas de Jason R. Henderson.`,
     recentPostsLabel: `Próximamente: publicaciones recientes`,
     buttons: {

--- a/app/(ui)/page.tsx
+++ b/app/(ui)/page.tsx
@@ -29,7 +29,6 @@ const Home: NextPage = async () => {
         <h2 className="mt-4 md:mt-6 text-xl md:text-2xl max-w-2xl text-center text-slate-800/70">
           {c.subtitlePrefix}
           <span className="whitespace-nowrap">{c.name}</span>
-          {c.subtitleSuffix}
         </h2>
         <div className="mt-12 w-full xs:w-96 md:w-auto flex flex-col md:flex-row gap-4">
           <div className="flex flex-col xs:flex-row flex-wrap justify-center gap-4 max-w-2xl">
@@ -111,7 +110,6 @@ const content = {
     title: `The Ancient Path`,
     subtitlePrefix: `Writings, teachings, and recommended resources from `,
     name: `Jason Henderson`,
-    subtitleSuffix: ``,
     metaDescription: `A blog and podcast containing the writings and teachings of Jason R. Henderson.`,
     recentPostsLabel: `Coming soon: recent posts`,
     buttons: {
@@ -153,7 +151,6 @@ const content = {
     title: `La Senda Antigua`,
     subtitlePrefix: `Escritos, enseñanzas y recursos recomendados de `,
     name: `Jason Henderson`,
-    subtitleSuffix: ``,
     metaDescription: `Un blog y podcast que contiene los escritos y enseñanzas de Jason R. Henderson.`,
     recentPostsLabel: `Próximamente: publicaciones recientes`,
     buttons: {


### PR DESCRIPTION
## Summary
- Added `whitespace-nowrap` to keep "Jason Henderson" on a single line in the home page subtitle
- Works at all screen sizes - the surrounding text wraps, but the name stays together

## Test plan
- [x] View the home page at various screen widths
- [x] Verify "Jason Henderson" never splits across two lines
- [x] Check both English and Spanish versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)